### PR TITLE
Fix:  bower.json should *not* contain .style.css in the main section.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,7 @@
   "license": "MIT",
   "main": [
     "dist/ng-sortable.js",
-    "dist/ng-sortable.css",
-    "dist/ng-sortable.style.css"
+    "dist/ng-sortable.css"
   ],
   "keywords": [
     "angular",


### PR DESCRIPTION
.style.css was wrongly added (https://github.com/a5hik/ng-sortable/commit/b6ece33858b960971d28510160435a30d24a3c10) to the main section.   it should **not** be there.
See: https://github.com/a5hik/ng-sortable/pull/47 for why.  the whole idea is that your style is not forced in to the app,  it is optional.
