### PR TITLE
Allow use of relative positioning on the container

### DIFF
--- a/source/sortable-helper.js
+++ b/source/sortable-helper.js
@@ -162,16 +162,29 @@
          * @param element - the dom element
          * @param pos - current position
          * @param container - the bounding container.
+         * @param containerPositioning - absolute or relative positioning.
          * @param {Object} [scrollableContainer] (optional) Scrollable container object
          */
-        movePosition: function (event, element, pos, container, scrollableContainer) {
+        movePosition: function (event, element, pos, container, containerPositioning, scrollableContainer) {
           var bounds;
+          var useRelative = (containerPositioning === 'relative');
 
           element.x = event.pageX - pos.offsetX;
           element.y = event.pageY - pos.offsetY;
 
           if (container) {
             bounds = this.offset(container, scrollableContainer);
+
+            if (useRelative) {
+              // reduce positioning by bounds
+              element.x -= bounds.left;
+              element.y -= bounds.top;
+
+              // reset bounds
+              bounds.left = 0;
+              bounds.top = 0;
+            }
+
             if (element.x < bounds.left) {
               element.x = bounds.left;
             } else if (element.x >= bounds.width + bounds.left - this.offset(element).width) {

--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -37,6 +37,7 @@
             itemPosition, //drag item element position.
             dragItemInfo, //drag item data.
             containment,//the drag container.
+            containerPositioning, // absolute or relative positioning.
             dragListen,// drag listen event.
             scrollableContainer, //the scrollable container
             dragStart,// drag start event.
@@ -146,6 +147,9 @@
             //capture mouse move on containment.
             containment.css('cursor', 'move');
 
+            // container positioning
+            containerPositioning = scope.sortableScope.options.containerPositioning || 'absolute';
+
             dragItemInfo = $helper.dragItem(scope);
             tagName = scope.itemScope.element.prop('tagName');
 
@@ -171,7 +175,7 @@
             dragElement.append(scope.itemScope.element);
 
             containment.append(dragElement);
-            $helper.movePosition(eventObj, dragElement, itemPosition, containment, scrollableContainer);
+            $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);
 
             scope.sortableScope.$apply(function () {
               scope.callbacks.dragStart(dragItemInfo.eventArgs());
@@ -248,7 +252,7 @@
               event.preventDefault();
 
               eventObj = $helper.eventObj(event);
-              $helper.movePosition(eventObj, dragElement, itemPosition, containment, scrollableContainer);
+              $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);
 
               targetX = eventObj.pageX - $document[0].documentElement.scrollLeft;
               targetY = eventObj.pageY - ($window.pageYOffset || $document[0].documentElement.scrollTop);


### PR DESCRIPTION
This pull-request provides a solution to #56 by allowing the use of relative positioning via the options object.

I can't see where your documentation on how to use containment is in order to update it to reference this, but essentially if the containment object has relative positioning, the option `containerPositioning` needs to be set to `'relative'`.
