### PR TITLE
Additional Placeholder Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ The directives are structured like below.
 - Added a Jquery like 'containment' option to the sortable to prevent the drag outside specified bounds.
 - The 'is-enabled' attribute on as-sortable to determine Drag at runTime.
 
+#### Placeholder:
+- A placeholder element is created using the same tag as the as-sortable-item element
+- CSS styling may be applied via the 'as-sortable-placeholder' class
+- Additional classes may be applied via the 'additionalPlaceholderClass' option provided to the as-sortable item. e.g.
+    in JS:
+```$scope.sortableOptions = { additionalPlaceholderClass: 'some-class' };```
+    in HTML:
+```<div as-sortable="sortableOptions">
+   ...
+</div>```
+
 #### Callbacks:
 
 Following callbacks are defined, and should be overridden to perform custom logic.

--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -158,7 +158,8 @@
             dragElement.css('width', $helper.width(scope.itemScope.element) + 'px');
             dragElement.css('height', $helper.height(scope.itemScope.element) + 'px');
 
-            placeHolder = angular.element($document[0].createElement(tagName)).addClass(sortableConfig.placeHolderClass);
+            placeHolder = angular.element($document[0].createElement(tagName))
+                .addClass(sortableConfig.placeHolderClass).addClass(scope.sortableScope.options.additionalPlaceholderClass);
             placeHolder.css('width', $helper.width(scope.itemScope.element) + 'px');
             placeHolder.css('height', $helper.height(scope.itemScope.element) + 'px');
 


### PR DESCRIPTION
I want to be able to apply an existing class to the placeholder.

My scenario is that I am using bootstrap wells for the styling of my items and I don't want to have to replicate the style from a well onto the .as-sortable-placeholder class. Instead, I want to be able to just apply the .well class to my placeholder.

This pull-request allows for `additionalPlaceholderClass` to be a defined on the options object passed to the as-sortable directive.

I have also updated the Readme to include documentation regarding how the placeholders are constructed, how they may be styled and how to use this additional class option.
