### PR TITLE
Return proper widths and heights (including decimals) from $helper

### DIFF
--- a/source/sortable-helper.js
+++ b/source/sortable-helper.js
@@ -20,7 +20,7 @@
          * @returns {String} Height
          */
         height: function (element) {
-          return element.prop('offsetHeight');
+          return element[0].getBoundingClientRect().height;
         },
 
         /**
@@ -30,7 +30,7 @@
          * @returns {String} Width
          */
         width: function (element) {
-          return element.prop('offsetWidth');
+          return element[0].getBoundingClientRect().width;
         },
 
         /**


### PR DESCRIPTION
$helper width() and height() methods return numbers rounded to the nearest decimal. This creates a problem with layouts that use percentage dimensions (e.g. Bootstrap grids) because a widths like 205.5px gets rounded to 206px and then the layout collapses.

The proper way of getting the dimensions is taken from http://stackoverflow.com/questions/3603065/how-to-make-jquery-to-not-round-value-returned-by-width.