### PR TITLE
Adding Classes for DropTarget when Dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ e.g.
 ```<div class="as-sortable-drop-target as-sortable-dragging"></div>````
 
     in CSS
-```.as-sortable-drop-target.as-sortable-dragging
+    .as-sortable-drop-target.as-sortable-dragging
        border: 1px dotted #000 !important;
-    }```
+    }
           
 
 #### Callbacks:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ The directives are structured like below.
    ...
 </div>```
 
+#### DropTarget and Dragging
+- CSS styling may be applied via the "as-sortable-drop-target" class
+- When the "as-sortable-item" is being dragged, the CSS class "as-sortable-dragging" is added to all elements with the class "as-sortable-drop-target".
+e.g.
+    in HTML
+```<!--not dragging-->````
+```<div class="as-sortable-drop-target"></div>````
+```<!--when dragging as-sortable-item-->```
+```<div class="as-sortable-drop-target as-sortable-dragging"></div>````
+
+    in CSS
+```.as-sortable-drop-target.as-sortable-dragging
+       border: 1px dotted #000 !important;
+    }```
+          
+
 #### Callbacks:
 
 Following callbacks are defined, and should be overridden to perform custom logic.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ e.g.
 ```<div class="as-sortable-drop-target as-sortable-dragging"></div>````
 
     in CSS
-    .as-sortable-drop-target.as-sortable-dragging
+    .as-sortable-drop-target.as-sortable-dragging{
        border: 1px dotted #000 !important;
     }
           

--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -268,6 +268,9 @@
               $document[0].elementFromPoint(targetX, targetY);
               targetElement = angular.element($document[0].elementFromPoint(targetX, targetY));
               dragElement.removeClass(sortableConfig.hiddenClass);
+              
+              //Set Class as dragging starts
+              $("."+ sortableConfig.dropTarget).addClass(sortableConfig.dragging);
 
               targetScope = targetElement.scope();
 
@@ -382,6 +385,8 @@
             if (dragElement) {
               //rollback all the changes.
               rollbackDragChanges();
+              //Remove dragging class when dragging ends
+              $("."+sortableConfig.dropTarget).removeClass(sortableConfig.dragging);
               // update model data
               dragItemInfo.apply();
               scope.sortableScope.$apply(function () {

--- a/source/sortable-main.js
+++ b/source/sortable-main.js
@@ -33,6 +33,8 @@
       handleClass: 'as-sortable-item-handle',
       placeHolderClass: 'as-sortable-placeholder',
       dragClass: 'as-sortable-drag',
-      hiddenClass: 'as-sortable-hidden'
+      hiddenClass: 'as-sortable-hidden',
+      dropTarget:'as-sortable-drop-target',
+      dragging:'as-sortable-dragging'
     });
 }());


### PR DESCRIPTION
Users can now add a DropTarget class to their DropTargets and add styling to them when dragging.