### PR TITLE
Clone HTML elements on drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Demo Includes:
 - Preventing/Allowing Drop Zone can be determined at run time.
 - Enable/Disable Drag at run time.
 - Drag Boundary can be defined.
+- Cloning (set clone = true on your SortOptions. Clones the dragged HTML element instead of moving it)
 
 #### Implementation Details:
 

--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -171,7 +171,17 @@
             scope.itemScope.element.after(placeHolder);
             //hidden place element in original position.
             scope.itemScope.element.after(placeElement);
-            dragElement.append(scope.itemScope.element);
+            
+			if (typeof (scope.options.clone) === 'undefined') {
+            	scope.options.clone = false;
+            };
+
+			//if the user has requested cloning then clone the element before appending it it to the dragElement.
+            if (scope.options.clone == true) {
+            	dragElement.append(scope.itemScope.element.clone());
+            } else {
+            	dragElement.append(scope.itemScope.element);
+            }
 
             containment.append(dragElement);
             $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);

--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -172,15 +172,15 @@
             //hidden place element in original position.
             scope.itemScope.element.after(placeElement);
             
-			if (typeof (scope.options.clone) === 'undefined') {
-            	scope.options.clone = false;
+            if (typeof (scope.options.clone) === 'undefined') {
+              scope.options.clone = false;
             };
 
-			//if the user has requested cloning then clone the element before appending it it to the dragElement.
+            //if the user has requested cloning then clone the element before appending it it to the dragElement.
             if (scope.options.clone == true) {
-            	dragElement.append(scope.itemScope.element.clone());
+              dragElement.append(scope.itemScope.element.clone());
             } else {
-            	dragElement.append(scope.itemScope.element);
+              dragElement.append(scope.itemScope.element);
             }
 
             containment.append(dragElement);


### PR DESCRIPTION
If scope.options.clone is set to true (false is default, as per existing behaviour) then the HTML element is cloned before being appended to the dragElement. This means that items do not get removed from the DOM on dragStart. The model will still be moved/removed - you can avoid this by copy/restoring the sortableScope as discussed in #3 / #20.