### PR TITLE
Changed sortable scope target element

### DIFF
--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -312,6 +312,7 @@
                 }
               }
               if (targetScope.type === 'sortable') {//sortable scope.
+                targetElement = angular.element(placeElement).parent();
                 if (targetScope.accept(scope, targetScope) &&
                   targetElement[0].parentNode !== targetScope.element[0]) {
                   //moving over sortable bucket. not over item.


### PR DESCRIPTION
Changed sortable scope target element to the parent of 'placeElement'. 

This fixes a bug where the placeHolder element would be appended to the wrong parent if the "as-sortable-item" element isn't a direct child of the 'as-sortable' element. This fixes flickering when using as-sortable on a table element while using a tbody or similar.

This might fix #96 and #132.