### PR TITLE
chore(version): bump to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you use this module you can give it a thumbs up at [http://ngmodules.org/modu
 
 #### Release:
 
-Latest release version 1.2.0
+Latest release version 1.2.1
 
 #### Demo Page:
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-sortable",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/a5hik/ng-sortable",
   "author": "Muhammed Ashik <https://github.com/a5hik>",
   "description": "Angular Library for Drag and Drop, supports Sortable and Draggable.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-sortable",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/a5hik/ng-sortable",
   "author": "Muhammed Ashik <https://github.com/a5hik>",
   "description": "Angular Library for Drag and Drop, supports Sortable and Draggable.",


### PR DESCRIPTION
As some of us depend on the latest fixes (https://github.com/a5hik/ng-sortable/issues/112), and use bower.   please bump the version up, otherwise we have to bower install from #master *(which is bad...)*

Thanks.