### PR TITLE
fix require error with browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/ng-sortable');
+module.exports = 'as.sortable';

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "homepage": "https://github.com/a5hik/ng-sortable",
   "author": "Muhammed Ashik <https://github.com/a5hik>",
   "description": "Angular Library for Drag and Drop, supports Sortable and Draggable.",
-  "main": [
-    "dist/ng-sortable.min.js",
-    "dist/ng-sortable.min.css"
-  ],
+  "main": "index.js",
   "keywords": [
     "angular",
     "drag",


### PR DESCRIPTION
when used with npm and browserify.

var angular = require('angular');
var uiSortable = require('ng-sortable');

browserify will throw an error:
TypeError: Arguments to path.resolve must be strings

the "main" field must be a string, but it is an array in package.json.

And it is a common practice that third party module of angular should export its module name, which is what the index.js file for. 
