### PR TITLE
Make KanbanController.js consistent with readme

### DIFF
--- a/demo/scripts/controllers/KanbanController.js
+++ b/demo/scripts/controllers/KanbanController.js
@@ -11,7 +11,7 @@ angular.module('demoApp').controller('KanbanController', ['$scope', 'BoardServic
 
     //restrict move across columns. move only within column.
     /*accept: function (sourceItemHandleScope, destSortableScope) {
-     return sourceItemHandleScope.itemScope.sortableScope.$id !== destSortableScope.$id;
+     return sourceItemHandleScope.itemScope.sortableScope.$id === destSortableScope.$id;
      },*/
     itemMoved: function (event) {
       event.source.itemScope.modelValue.status = event.dest.sortableScope.$parent.column.name;


### PR DESCRIPTION
Restricting movement to within a column requires that the above `$id`s be equal, not unequal (see readme.md). This commented-out section is inconsistent with that and says exactly the opposite.