### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Following callbacks are defined, and should be overridden to perform custom logi
      destItemScope - the destination item scope, this is an optional Param.(Must check for undefined).
 
 - callbacks.orderChanged = function({type: Object}) // triggered when item order is changed with in the same column.
-- callbacks.itemMoved = function({type: Object}) // triggered when an item is moved accross columns.
+- callbacks.itemMoved = function({type: Object}) // triggered when an item is moved across columns.
 - callbacks.dragStart = function({type: Object}) // triggered on drag start.
 - callbacks.dragEnd = function({type: Object}) // triggered on drag end.
 


### PR DESCRIPTION
@a5hik, I've corrected a typographical error in the documentation of the [ng-sortable](https://github.com/a5hik/ng-sortable) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.