### PR TITLE
Fixes for table rows

### DIFF
--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -19,6 +19,19 @@
     $scope.type = 'handle';
   }]);
 
+  //Check if a node is parent to another node
+  function isParent(possibleParent, elem) {
+    if(!elem || elem.nodeName === 'HTML') {
+      return false;
+    }
+
+    if(elem.parentNode === possibleParent) {
+      return true;
+    }
+
+    return isParent(possibleParent, elem.parentNode);
+  }
+
   /**
    * Directive for sortable item handle.
    */
@@ -76,7 +89,7 @@
               }
             }
           });
-          
+
           scope.$on('$destroy', function () {
             angular.element($document[0].body).unbind('keydown', escapeListen);
           });
@@ -249,8 +262,10 @@
            * @param targetScope the target scope
            */
           function insertBefore(targetElement, targetScope) {
-            // Ensure the placeholder is visible in the target.
-            placeHolder.css('display', 'block');
+            // Ensure the placeholder is visible in the target (unless it's a table row)
+            if (placeHolder.css('display') !== 'table-row') {
+              placeHolder.css('display', 'block');
+            }
 
             targetElement[0].parentNode.insertBefore(placeHolder[0], targetElement[0]);
             dragItemInfo.moveTo(targetScope.sortableScope, targetScope.index());
@@ -263,8 +278,10 @@
            * @param targetScope the target scope
            */
           function insertAfter(targetElement, targetScope) {
-            // Ensure the placeholder is visible in the target.
-            placeHolder.css('display', 'block');
+            // Ensure the placeholder is visible in the target (unless it's a table row)
+            if (placeHolder.css('display') !== 'table-row') {
+              placeHolder.css('display', 'block');
+            }
 
             targetElement.after(placeHolder);
             dragItemInfo.moveTo(targetScope.sortableScope, targetScope.index() + 1);
@@ -338,7 +355,7 @@
 
               if (targetScope.type === 'sortable') {//sortable scope.
                 if (targetScope.accept(scope, targetScope) &&
-                  targetElement[0].parentNode !== targetScope.element[0]) {
+                  !isParent(targetScope.element[0], targetElement[0])) {
                   //moving over sortable bucket. not over item.
                   if (!isPlaceHolderPresent(targetElement)) {
                     targetElement[0].appendChild(placeHolder[0]);


### PR DESCRIPTION
This PR addresses a few issues that I was having with tables, in particular:
- While dragging we shouldn't apply the display:block style to the element if it's a table row (tr) otherwise we would mess up the entire table layout. A tr always has to have a display: table-row.
- If a sortable item is not a direct child of as-sortable we will receive this error: "Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': The new child element contains the parent." while dragging. We can fix this by making sure to search the parents of the sortable item recursively.