### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The move failure Impl here just reverts the moved item to its original location.
            */
           moveFailure = function() {   
                eventObj.dest.sortableScope.removeItem(eventObj.dest.index);
-               eventObj.source.itemScope.sortableScope.insertItem(eventObj.source.index, eventObj.source.itemScope.task);
+               eventObj.source.itemScope.sortableScope.insertItem(eventObj.source.index, eventObj.source.itemScope.item);
           };
     }
 


### PR DESCRIPTION
There is an error in the Section: [How To Revert Move After Validation Failure](https://github.com/a5hik/ng-sortable#how-to-revert-move-after-validation-failure)
`eventObj.source.itemScope.sortableScope.insertItem(eventObj.source.index, eventObj.source.itemScope.task);`
Should be:
`eventObj.source.itemScope.sortableScope.insertItem(eventObj.source.index, eventObj.source.itemScope.item);`
or
`eventObj.source.itemScope.sortableScope.insertItem(eventObj.source.index, eventObj.source.itemScope.modelValue);`

Thanks for this awesome module :+1: