### PR TITLE
Issue 347

### DIFF
--- a/source/sortable-helper.js
+++ b/source/sortable-helper.js
@@ -226,7 +226,7 @@
             targetElementOffset: null,
             sourceInfo: {
               index: item.index(),
-              itemScope: item,
+              itemScope: (item.itemScope || item),
               sortableScope: item.sortableScope
             },
             canMove: function(itemPosition, targetElement, targetElementOffset) {

--- a/source/sortable-helper.js
+++ b/source/sortable-helper.js
@@ -226,7 +226,7 @@
             targetElementOffset: null,
             sourceInfo: {
               index: item.index(),
-              itemScope: item.itemScope,
+              itemScope: item,
               sortableScope: item.sortableScope
             },
             canMove: function(itemPosition, targetElement, targetElementOffset) {


### PR DESCRIPTION
Fixes #347 
- The object being passed to `dragItem` is an `itemScope` therefore `item.itemScope` is undefined.  This code creates a fall back to use the item itself, which seems to resolve the issue as I am experiencing it.