### PR TITLE
fixing the `display` value check to include CSS computed style as well

### DIFF
--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -284,7 +284,8 @@
            */
           function insertBefore(targetElement, targetScope) {
             // Ensure the placeholder is visible in the target (unless it's a table row)
-            if (placeHolder.css('display') !== 'table-row') {
+            var placeHolderDisplayVal = placeHolder[0].currentStyle ? placeHolder[0].currentStyle.display : getComputedStyle(placeHolder[0], null).display;
+            if (placeHolder.css('display') !== 'table-row' && placeHolderDisplayVal !== 'table-row') {
               placeHolder.css('display', 'block');
             }
             if (!targetScope.sortableScope.options.clone) {
@@ -301,7 +302,8 @@
            */
           function insertAfter(targetElement, targetScope) {
             // Ensure the placeholder is visible in the target (unless it's a table row)
-            if (placeHolder.css('display') !== 'table-row') {
+            var placeHolderDisplayVal = placeHolder[0].currentStyle ? placeHolder[0].currentStyle.display : getComputedStyle(placeHolder[0], null).display;
+            if (placeHolder.css('display') !== 'table-row' && placeHolderDisplayVal !== 'table-row') {
               placeHolder.css('display', 'block');
             }
             if (!targetScope.sortableScope.options.clone) {


### PR DESCRIPTION
Right now `insertBefore` and `insertAfter` look only after `element.style` inline CSS, which in case of unaltered by JS, normal table would be empty.

User Agent Stylesheet default styles and user styles have to be checked via either `Element.currentStyle` (IE6) or standardized `window.getComputedStyle`.

This way it will detect default `table-row` value for `display` property and properly ignore it.