### PR TITLE
Fixes Issue #401

### DIFF
--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -164,7 +164,7 @@
 
             var eventObj, tagName;
 
-            if (!hasTouch && (event.button === 2 || event.which === 3)) {
+            if (event.button === 2 || event.which === 3) {
               // disable right click
               return;
             }


### PR DESCRIPTION
As suggestd by @markvp, remove the `!hasTouch` check to allow Chrome
with Mouse and Touch to work properly on right click.