### PR TITLE
fix: use changedTouches instead of targetTouches

### DIFF
--- a/source/sortable-helper.js
+++ b/source/sortable-helper.js
@@ -62,10 +62,10 @@
          */
         eventObj: function (event) {
           var obj = event;
-          if (event.targetTouches !== undefined) {
-            obj = event.targetTouches.item(0);
-          } else if (event.originalEvent !== undefined && event.originalEvent.targetTouches !== undefined) {
-            obj = event.originalEvent.targetTouches.item(0);
+          if (event.changedTouches !== undefined) {
+            obj = event.changedTouches.item(0);
+          } else if (event.originalEvent !== undefined && event.originalEvent.changedTouches !== undefined) {
+            obj = event.originalEvent.changedTouches.item(0);
           }
           return obj;
         },


### PR DESCRIPTION
Fixes incompatibility with ios 13, where sometimes targetTouches
doesn't contain any Touch objects inside the touchmove event.

See also https://github.com/nolimits4web/swiper/pull/3259